### PR TITLE
Widen dependency on base

### DIFF
--- a/syb.cabal
+++ b/syb.cabal
@@ -30,7 +30,7 @@ source-repository head
 
 Library {
   hs-source-dirs:         src
-  build-depends:          base >= 4.0 && < 4.5
+  build-depends:          base >= 4.0 && < 4.6
   exposed-modules:        Data.Generics,
                           Data.Generics.Basics,
                           Data.Generics.Instances,


### PR DESCRIPTION
This is required to build on GHC 7.4. It'd be great if you could make a new release soon.
