### PR TITLE
Redefine recursive traversals via local helper functions

### DIFF
--- a/src/Data/Generics/Schemes.hs
+++ b/src/Data/Generics/Schemes.hs
@@ -4,12 +4,12 @@
 -- Module      :  Data.Generics.Schemes
 -- Copyright   :  (c) The University of Glasgow, CWI 2001--2003
 -- License     :  BSD-style (see the LICENSE file)
--- 
+--
 -- Maintainer  :  generics@haskell.org
 -- Stability   :  experimental
 -- Portability :  non-portable (local universal quantification)
 --
--- \"Scrap your boilerplate\" --- Generic programming in Haskell 
+-- \"Scrap your boilerplate\" --- Generic programming in Haskell
 -- See <http://www.cs.uu.nl/wiki/GenericProgramming/SYB>. The present module
 -- provides frequently used generic traversal schemes.
 --
@@ -47,8 +47,8 @@ import Data.Data
 import Data.Generics.Aliases
 import Control.Monad
 
-
 -- | Apply a transformation everywhere in bottom-up manner
+
 everywhere :: (forall a. Data a => a -> a)
            -> (forall a. Data a => a -> a)
 
@@ -127,7 +127,7 @@ something :: GenericQ (Maybe u) -> GenericQ (Maybe u)
 
 -- "something" can be defined in terms of "everything"
 -- when a suitable "choice" operator is used for reduction
--- 
+--
 something = everything orElse
 
 

--- a/src/Data/Generics/Schemes.hs
+++ b/src/Data/Generics/Schemes.hs
@@ -55,67 +55,90 @@ everywhere :: (forall a. Data a => a -> a)
 -- Use gmapT to recurse into immediate subterms;
 -- recall: gmapT preserves the outermost constructor;
 -- post-process recursively transformed result via f
--- 
-everywhere f = f . gmapT (everywhere f)
-
+--
+everywhere f = go
+  where
+    go :: forall a. Data a => a -> a
+    go = f . gmapT go
 
 -- | Apply a transformation everywhere in top-down manner
 everywhere' :: (forall a. Data a => a -> a)
             -> (forall a. Data a => a -> a)
 
 -- Arguments of (.) are flipped compared to everywhere
-everywhere' f = gmapT (everywhere' f) . f
+everywhere' f = go
+  where
+    go :: forall a. Data a => a -> a
+    go = gmapT go . f
 
 
 -- | Variation on everywhere with an extra stop condition
 everywhereBut :: GenericQ Bool -> GenericT -> GenericT
 
 -- Guarded to let traversal cease if predicate q holds for x
-everywhereBut q f x
-    | q x       = x
-    | otherwise = f (gmapT (everywhereBut q f) x)
+everywhereBut q f = go
+  where
+    go :: GenericT
+    go x
+      | q x       = x
+      | otherwise = f (gmapT go x)
 
 
 -- | Monadic variation on everywhere
-everywhereM :: Monad m => GenericM m -> GenericM m
+everywhereM :: forall m. Monad m => GenericM m -> GenericM m
 
 -- Bottom-up order is also reflected in order of do-actions
-everywhereM f x = do x' <- gmapM (everywhereM f) x
-                     f x'
+everywhereM f = go
+  where
+    go :: GenericM m
+    go x = do
+      x' <- gmapM go x
+      f x'
 
 
 -- | Apply a monadic transformation at least somewhere
-somewhere :: MonadPlus m => GenericM m -> GenericM m
+somewhere :: forall m. MonadPlus m => GenericM m -> GenericM m
 
 -- We try "f" in top-down manner, but descent into "x" when we fail
 -- at the root of the term. The transformation fails if "f" fails
 -- everywhere, say succeeds nowhere.
--- 
-somewhere f x = f x `mplus` gmapMp (somewhere f) x
+--
+somewhere f = go
+  where
+    go :: GenericM m
+    go x = f x `mplus` gmapMp go x
 
 
 -- | Summarise all nodes in top-down, left-to-right order
-everything :: (r -> r -> r) -> GenericQ r -> GenericQ r
+everything :: forall r. (r -> r -> r) -> GenericQ r -> GenericQ r
 
 -- Apply f to x to summarise top-level node;
 -- use gmapQ to recurse into immediate subterms;
 -- use ordinary foldl to reduce list of intermediate results
--- 
-everything k f x = foldl k (f x) (gmapQ (everything k f) x)
+--
+everything k f = go
+  where
+    go :: GenericQ r
+    go x = foldl k (f x) (gmapQ go x)
 
 -- | Variation of "everything" with an added stop condition
-everythingBut :: (r -> r -> r) -> GenericQ (r, Bool) -> GenericQ r
-everythingBut k f x = let (v, stop) = f x
-                      in if stop
-                           then v
-                           else foldl k v (gmapQ (everythingBut k f) x)
+everythingBut :: forall r. (r -> r -> r) -> GenericQ (r, Bool) -> GenericQ r
+everythingBut k f = go
+  where
+    go :: GenericQ r
+    go x = let (v, stop) = f x
+           in if stop
+                then v
+                else foldl k v (gmapQ go x)
 
 -- | Summarise all nodes in top-down, left-to-right order, carrying some state
 -- down the tree during the computation, but not left-to-right to siblings.
-everythingWithContext :: s -> (r -> r -> r) -> GenericQ (s -> (r, s)) -> GenericQ r
-everythingWithContext s0 f q x =
-  foldl f r (gmapQ (everythingWithContext s' f q) x)
-    where (r, s') = q x s0
+everythingWithContext :: forall s r. s -> (r -> r -> r) -> GenericQ (s -> (r, s)) -> GenericQ r
+everythingWithContext s0 f q = go s0
+  where
+    go :: s -> GenericQ r
+    go s x = foldl f r (gmapQ (go s') x)
+      where (r, s') = q x s
 
 -- | Get a list of all entities that meet a predicate
 listify :: Typeable r => (r -> Bool) -> GenericQ [r]
@@ -136,8 +159,11 @@ something = everything orElse
 --   2nd argument o is for reduction of results from subterms;
 --   3rd argument f updates the synthesised data according to the given term
 --
-synthesize :: s  -> (t -> s -> s) -> GenericQ (s -> t) -> GenericQ t
-synthesize z o f x = f x (foldr o z (gmapQ (synthesize z o f) x))
+synthesize :: forall s t. s  -> (t -> s -> s) -> GenericQ (s -> t) -> GenericQ t
+synthesize z o f = go
+  where
+    go :: GenericQ t
+    go x = f x (foldr o z (gmapQ go x))
 
 
 -- | Compute size of an arbitrary data structure

--- a/src/Data/Generics/Twins.hs
+++ b/src/Data/Generics/Twins.hs
@@ -266,12 +266,15 @@ geq x0 y0 = geq' x0 y0
 -- | Generic zip controlled by a function with type-specific branches
 gzip :: GenericQ (GenericM Maybe) -> GenericQ (GenericM Maybe)
 -- See testsuite/.../Generics/gzip.hs for an illustration
-gzip f x y =
-  f x y
-  `orElse`
-  if toConstr x == toConstr y
-    then gzipWithM (gzip f) x y
-    else Nothing
+gzip f = go
+  where
+    go :: GenericQ (GenericM Maybe)
+    go x y =
+      f x y
+      `orElse`
+      if toConstr x == toConstr y
+        then gzipWithM go x y
+        else Nothing
 
 -- | Generic comparison: an alternative to \"deriving Ord\"
 gcompare :: Data a => a -> a -> Ordering


### PR DESCRIPTION
This should improve library's performance because:

1. There will be less arguments passed around on each function invocation
2. Redefined via recursive helpers functions like `everywhere` could be automatically inlined at the call site by GHC. Before this change they were not eligible for inlining because they were recursive. Now their inlining information is automatically added to the `.hi` file by ghc (tested with 8.2.2).  