### PR TITLE
GHC 9 compatibility fixes

### DIFF
--- a/src/Data/Generics/Twins.hs
+++ b/src/Data/Generics/Twins.hs
@@ -287,7 +287,7 @@ gcompare = gcompare'
         in
         case (repX, repY) of
           (AlgConstr nX,   AlgConstr nY)   ->
-            nX `compare` nY `mappend` mconcat (gzipWithQ gcompare' x y)
+            nX `compare` nY `mappend` mconcat (gzipWithQ (\a -> gcompare' a) x y)
           (IntConstr iX,   IntConstr iY)   -> iX `compare` iY
           (FloatConstr rX, FloatConstr rY) -> rX `compare` rY
           (CharConstr cX,  CharConstr cY)  -> cX `compare` cY

--- a/tests/Ext1.hs
+++ b/tests/Ext1.hs
@@ -12,6 +12,7 @@ This example records some experiments with polymorphic datatypes.
 import Test.HUnit
 
 import Data.Generics
+import GHC.Exts (unsafeCoerce#)
 #if MIN_VERSION_base(4,8,0)
 import GHC.Base hiding(foldr)
 #else

--- a/tests/GetC.hs
+++ b/tests/GetC.hs
@@ -28,7 +28,7 @@ import Data.Generics  -- to access t's subterms and constructors.
 -- Some silly data types
 data T1 = T1a Int String | T1b String Int     deriving (Typeable, Data)
 data T2 = T2a Int Int    | T2b String String  deriving (Typeable, Data)
-data T3 = T3! Int                             deriving (Typeable, Data)
+data T3 = T3  !Int                            deriving (Typeable, Data)
 
 
 -- Test cases

--- a/tests/Twin.hs
+++ b/tests/Twin.hs
@@ -23,7 +23,7 @@ geq' x y =  toConstr x == toConstr y
          && and (gzipWithQ geq' x y)
 
 geq :: Data a => a -> a -> Bool
-geq = geq'
+geq a = geq' a
 
 newtype GQ r = GQ (GenericQ r)
 


### PR DESCRIPTION
This patch contains some minor changes to get `syb` compile with the current GHC HEAD (soon to be GHC 9).

* It imports 'unsafeCoerce#' from 'GHC.Exts': https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.0#base-415
* Eta-expand some fields: https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.0#base-415
* Remove whitespace after a bang pattern: https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.0#whitespace-sensitive-and-

I tried to choose the backwards compatible options, but I haven't tried this with older compiler versions.