### PR TITLE
Expand definition of gcompare to type check with simplified subsumption.

### DIFF
--- a/src/Data/Generics/Twins.hs
+++ b/src/Data/Generics/Twins.hs
@@ -278,9 +278,9 @@ gzip f = go
 
 -- | Generic comparison: an alternative to \"deriving Ord\"
 gcompare :: Data a => a -> a -> Ordering
-gcompare = gcompare'
+gcompare x' = gcompare' x'
   where
-    gcompare' :: (Data a, Data b) => a -> b -> Ordering
+    gcompare' :: Data a => a -> forall b. Data b => b -> Ordering
     gcompare' x y
       = let repX = constrRep $ toConstr x
             repY = constrRep $ toConstr y


### PR DESCRIPTION
Due to the implementation of simplified subsumption (https://github.com/ghc-proposals/ghc-proposals/blob/wip/spj-deep-skol/proposals/0000-simplify-subsumption.md), `gcompare` no longer type checks under GHC 9, and so this package fails to build.  By tweaking the internal type signature and eta-expanding a bit, it can be restored.