### PR TITLE
Employ a test framework (tasty) instead of naked HUnit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,18 +13,18 @@ before_cache:
 
 matrix:
   include:
-    - env: CABALVER=1.16 GHCVER=7.0.1
+    - env: CABALVER=2.4 GHCVER=7.0.1
       compiler: ": #GHC 7.0.1"
-      addons: {apt: {packages: [cabal-install-1.16,ghc-7.0.1], sources: [hvr-ghc]}}
-    - env: CABALVER=1.16 GHCVER=7.0.2
+      addons: {apt: {packages: [cabal-install-2.4,ghc-7.0.1], sources: [hvr-ghc]}}
+    - env: CABALVER=2.4 GHCVER=7.0.2
       compiler: ": #GHC 7.0.2"
-      addons: {apt: {packages: [cabal-install-1.16,ghc-7.0.2], sources: [hvr-ghc]}}
-    - env: CABALVER=1.16 GHCVER=7.0.3
+      addons: {apt: {packages: [cabal-install-2.4,ghc-7.0.2], sources: [hvr-ghc]}}
+    - env: CABALVER=2.4 GHCVER=7.0.3
       compiler: ": #GHC 7.0.3"
-      addons: {apt: {packages: [cabal-install-1.16,ghc-7.0.3], sources: [hvr-ghc]}}
-    - env: CABALVER=1.16 GHCVER=7.0.4
+      addons: {apt: {packages: [cabal-install-2.4,ghc-7.0.3], sources: [hvr-ghc]}}
+    - env: CABALVER=2.4 GHCVER=7.0.4
       compiler: ": #GHC 7.0.4"
-      addons: {apt: {packages: [cabal-install-1.16,ghc-7.0.4], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [cabal-install-2.4,ghc-7.0.4], sources: [hvr-ghc]}}
     - env: CABALVER=1.16 GHCVER=7.2.1
       compiler: ": #GHC 7.2.1"
       addons: {apt: {packages: [cabal-install-1.16,ghc-7.2.1], sources: [hvr-ghc]}}

--- a/syb.cabal
+++ b/syb.cabal
@@ -21,8 +21,7 @@ build-type:             Simple
 cabal-version:          >= 1.8
 tested-with:            GHC >=7.0 && <=7.10.2, GHC==7.11.*, GHC==8.0, GHC==8.2, GHC==8.4.4, GHC==8.6.5
 
-extra-source-files:     tests/*.hs,
-                        README.md,
+extra-source-files:     README.md,
                         ChangeLog
 
 source-repository head
@@ -61,6 +60,43 @@ test-suite unit-tests
   main-is:                Main.hs
   build-depends:          base
                         , syb
-                        , HUnit
+                        , tasty
+                        , tasty-hunit
                         , containers
                         , mtl
+  other-modules:          Bits
+                          Builders
+                          CompanyDatatypes
+                          Datatype
+                          Encode
+                          Ext
+                          Ext1
+                          Ext2
+                          FoldTree
+                          FreeNames
+                          GEq
+                          GMapQAssoc
+                          GRead
+                          GRead2
+                          GShow
+                          GShow2
+                          GZip
+                          GenUpTo
+                          GetC
+                          HList
+                          HOPat
+                          Labels
+                          LocalQuantors
+                          NestedDatatypes
+                          Newtype
+                          Paradise
+                          Perm
+                          Polymatch
+                          Reify
+                          Strings
+                          Tree
+                          Twin
+                          Typecase1
+                          Typecase2
+                          Where
+                          XML

--- a/tests/Bits.hs
+++ b/tests/Bits.hs
@@ -3,7 +3,7 @@
 module Bits (tests) where
 
 {-
- 
+
 This test exercices some oldies of generic programming, namely
 encoding terms as bit streams and decoding these bit streams in turn
 to obtain terms again. (This sort of function might actually be useful
@@ -34,7 +34,7 @@ encoded).
 
 -}
 
-import Test.HUnit
+import Test.Tasty.HUnit
 
 import Data.Generics
 import Data.Char
@@ -70,7 +70,7 @@ varNat2bin 0 = []
 varNat2bin x =
   ( ( if even x then Zero else One )
   : varNat2bin (x `div` 2)
-  ) 
+  )
 
 
 -- Encode a natural as a bit stream of fixed length
@@ -79,7 +79,7 @@ fixedNat2bin 0 0 = []
 fixedNat2bin p x | p>0 =
   ( ( if even x then Zero else One )
   : fixedNat2bin (p - 1) (x `div` 2)
-  ) 
+  )
 
 
 -- Decode a natural
@@ -197,7 +197,7 @@ readBin = result
   max :: Int
   max = maxConstrIndex myDataType
 
-  -- Convert a bit stream into a constructor 
+  -- Convert a bit stream into a constructor
   bin2con :: Bin -> Constr
   bin2con bin = indexConstr myDataType ((bin2nat bin) + 1)
 
@@ -217,8 +217,8 @@ tests = (   showBin True
         , ( showBin (1::Int)
         , ( showBin "1"
         , ( showBin genCom
-        , ( geq genCom genCom' 
-        )))))) ~=? output
+        , ( geq genCom genCom'
+        )))))) @=? output
  where
   genCom' = fromJust (fst (unReadB readBin (showBin genCom))) :: Company
 

--- a/tests/Builders.hs
+++ b/tests/Builders.hs
@@ -2,9 +2,9 @@
 
 module Builders (tests) where
 
--- Testing Data.Generics.Builders functionality 
+-- Testing Data.Generics.Builders functionality
 
-import Test.HUnit
+import Test.Tasty.HUnit
 
 import Data.Data
 import Data.Generics.Builders
@@ -15,6 +15,6 @@ tests = ( constrs :: [Maybe Int]
         , constrs :: [String]
         , constrs :: [Either Int Float]
         , constrs :: [((), Integer)]
-        ) ~=? output
+        ) @=? output
 
 output = ([Nothing,Just 0],["","\NUL"],[Left 0,Right 0.0],[((),0)])

--- a/tests/Datatype.hs
+++ b/tests/Datatype.hs
@@ -4,7 +4,7 @@
 -- These are simple tests to observe (data)type representations.
 module Datatype  where
 
-import Test.HUnit
+import Test.Tasty.HUnit
 
 import Data.Tree
 import Data.Generics
@@ -32,7 +32,7 @@ tests =  show ( myTypeRep
             , ( tyconModule myString2
             , ( tyconUQname myString2
             ))))))
-       ~?= output
+       @?= output
 
 #if __GLASGOW_HASKELL__ >= 709
 -- In GHC 7.10 module name is stripped from DataType
@@ -44,7 +44,7 @@ output = "(MyDataType Int,(DataType {tycon = \"Datatype.MyDataType\", datarep = 
 #else
 
 tests = show ( myTypeRep, myDataType )
-        ~?= output
+        @?= output
 
 #if __GLASGOW_HASKELL__ >= 701
 output = "(MyDataType Int,DataType {tycon = \"Datatype.MyDataType\", datarep = AlgRep [MyDataType]})"

--- a/tests/Ext1.hs
+++ b/tests/Ext1.hs
@@ -9,7 +9,7 @@ This example records some experiments with polymorphic datatypes.
 
 -}
 
-import Test.HUnit
+import Test.Tasty.HUnit
 
 import Data.Generics
 import GHC.Exts (unsafeCoerce#)
@@ -37,7 +37,7 @@ extListQ' :: Data d
 extListQ' def ext d =
   if isList d
     then ext (unsafeCoerce d)
-    else def d 
+    else def d
 
 
 -- Test extListQ'
@@ -55,7 +55,7 @@ extListQ'' :: Data d
 extListQ'' def ext d =
   if isList d
     then undefined -- hard to avoid an ambiguous type
-    else def d 
+    else def d
 
 
 -- Test extListQ from Data.Generics.Aliases
@@ -98,7 +98,7 @@ isCons x = toConstr x == toConstr (():[])
 -- gmapQ for polymorphic lists
 gmapListQ :: forall a q. Data a => (forall a. Data a => a -> q) -> a -> [q]
 gmapListQ f x =
-  if not $ isList x 
+  if not $ isList x
     then error "gmapListQ"
     else if isNil x
            then []
@@ -124,6 +124,6 @@ tests = ( t1
         , ( t4
         , ( t5
         , ( t6
-        )))))) ~=? output
+        )))))) @=? output
 
 output = (0,(2,(0,(4,(0,4)))))

--- a/tests/Ext2.hs
+++ b/tests/Ext2.hs
@@ -4,7 +4,7 @@ module Ext2 (tests) where
 
 -- Tests for ext2 and friends
 
-import Test.HUnit
+import Test.Tasty.HUnit
 import Data.Generics
 
 
@@ -57,7 +57,7 @@ t4 = unifyPair (t4' :: Pair Int Char) t4' where
 
 
 -- Main function for testing
-tests = (t1, t2, t3, t4) ~=? output
+tests = (t1, t2, t3, t4) @=? output
 
 output = ((map flipPair s1, (flipPair p2, l2))
          ,(Just (flipPair p1),Nothing)

--- a/tests/FoldTree.hs
+++ b/tests/FoldTree.hs
@@ -27,7 +27,7 @@ distinctions' as well.
 
 module FoldTree (tests) where
 
-import Test.HUnit
+import Test.Tasty.HUnit
 
 -- Enable "ScrapYourBoilerplate"
 import Data.Generics
@@ -36,7 +36,7 @@ import Data.Generics
 -- A parameterised datatype for binary trees with data at the leafs
 data Tree a w = Leaf a
               | Fork (Tree a w) (Tree a w)
-              | WithWeight (Tree a w) w  
+              | WithWeight (Tree a w) w
        deriving (Typeable, Data)
 
 
@@ -59,9 +59,9 @@ mytree' = Fork (Leaf 42)
 -- Additionally we test everythingBut, stopping when we see a WithWeight node
 tests = show ( listify (\(_::Int) -> True)         mytree
              , everything (++) ([] `mkQ` fromLeaf) mytree
-             , everythingBut (++) 
+             , everythingBut (++)
                  (([],False) `mkQ` (\x -> (fromLeaf x, stop x))) mytree'
-             ) ~=? output
+             ) @=? output
   where
     fromLeaf :: Tree Int Int -> [Int]
     fromLeaf (Leaf x) = [x]

--- a/tests/FreeNames.hs
+++ b/tests/FreeNames.hs
@@ -20,7 +20,7 @@ Contributed by Ralf Laemmel, ralf@cwi.nl
 
 -}
 
-import Test.HUnit
+import Test.Tasty.HUnit
 
 import Data.Generics
 import Data.List
@@ -96,7 +96,7 @@ root of the present term, but subtract all the names that are declared
 at the root.
 
 -}
- 
+
 freeNames :: Data a => a -> [Name]
 freeNames x = ( (refsFun x)
                 `union`
@@ -113,6 +113,6 @@ explicit datatype declarations ;-)
 
 -}
 
-tests = freeNames sys1 ~=? output
+tests = freeNames sys1 @=? output
 
 output = ["id","C"]

--- a/tests/GEq.hs
+++ b/tests/GEq.hs
@@ -11,11 +11,11 @@ read term is equal to the original term in terms of "geq".
 
 -}
 
-import Test.HUnit
+import Test.Tasty.HUnit
 
 import Data.Generics
 import CompanyDatatypes
 
 tests = ( geq genCom genCom
         , geq genCom genCom'
-        ) ~=? (True,False)
+        ) @=? (True,False)

--- a/tests/GMapQAssoc.hs
+++ b/tests/GMapQAssoc.hs
@@ -25,7 +25,7 @@ Contributed by Ralf Laemmel, ralf@cwi.nl
 
 -}
 
-import Test.HUnit
+import Test.Tasty.HUnit
 
 import Data.Generics
 
@@ -48,7 +48,7 @@ data IntTree = Leaf Int | Fork IntTree IntTree
                deriving (Typeable, Data)
 
 
--- Select int if faced with a leaf 
+-- Select int if faced with a leaf
 leaf (Leaf i) = [i]
 leaf _        = []
 
@@ -63,6 +63,6 @@ term = Fork (Leaf 1) (Leaf 2)
 --
 tests = show ( gmapQ   ([] `mkQ` leaf) term
              , gmapQ'  ([] `mkQ` leaf) term
-             ) ~=? output
+             ) @=? output
 
 output = show ([[1],[2]],[[2],[1]])

--- a/tests/GRead.hs
+++ b/tests/GRead.hs
@@ -12,7 +12,7 @@ see str5.
 
 -}
 
-import Test.HUnit
+import Test.Tasty.HUnit
 
 import Data.Generics
 
@@ -39,7 +39,7 @@ tests = show ( ( [ gread str1,
                 , [[(Int,   String)]]
                 , [[([Int], String)]]
                 )
-             ) ~=? output
+             ) @=? output
 
 output = show
            ([[(True,"")],[],[]],[[(1,"")],[(2,"...")]],[[([],"")],[([1],"")]])

--- a/tests/GShow.hs
+++ b/tests/GShow.hs
@@ -1,33 +1,33 @@
 {-# OPTIONS -fglasgow-exts #-}
- 
+
 module GShow (tests) where
 
 {-
- 
+
 The generic show example from the 2nd boilerplate paper.
 (There were some typos in the ICFP 2004 paper.)
 Also check out Data.Generics.Text.
- 
+
 -}
 
-import Test.HUnit
+import Test.Tasty.HUnit
 
 import Data.Generics hiding (gshow)
 import Prelude hiding (showString)
 
- 
+
 gshow :: Data a => a -> String
 gshow = gshow_help `extQ` showString
 
 gshow_help :: Data a => a -> String
-gshow_help t 
+gshow_help t
      =  "("
      ++ showConstr (toConstr t)
      ++ concat (intersperse " " (gmapQ gshow t))
      ++ ")"
 
 showString :: String -> String
-showString s = "\"" ++ concat (map escape s) ++ "\"" 
+showString s = "\"" ++ concat (map escape s) ++ "\""
                where
                  escape '\n' = "\\n"
                  escape other_char = [other_char]
@@ -37,7 +37,7 @@ gshowList xs
     = "[" ++ concat (intersperse "," (map gshow xs)) ++ "]"
 
 gshow' :: Data a => a -> String
-gshow' = gshow_help `ext1Q` gshowList 
+gshow' = gshow_help `ext1Q` gshowList
                     `extQ`  showString
 
 intersperse :: a -> [a] -> [a]
@@ -47,6 +47,6 @@ intersperse x (e:es) = (e:(x:intersperse x es))
 
 tests = ( gshow' "foo"
         , gshow' [True,False]
-        ) ~=? output
+        ) @=? output
 
 output = ("\"foo\"","[(True),(False)]")

--- a/tests/GShow2.hs
+++ b/tests/GShow2.hs
@@ -10,12 +10,12 @@ output of the program should be some representation of the infamous
 
 -}
 
-import Test.HUnit
+import Test.Tasty.HUnit
 
 import Data.Generics
 import CompanyDatatypes
 
-tests = gshow genCom ~=? output
+tests = gshow genCom @=? output
 
 {-
 

--- a/tests/GZip.hs
+++ b/tests/GZip.hs
@@ -11,13 +11,13 @@ encounter salaries we take the maximum of the two.
 
 -}
 
-import Test.HUnit
+import Test.Tasty.HUnit
 
 import Data.Generics
 import CompanyDatatypes
 
 -- The main function which prints the result of zipping
-tests = gzip (\x y -> mkTT maxS x y) genCom1 genCom2 ~=? output
+tests = gzip (\x y -> mkTT maxS x y) genCom1 genCom2 @=? output
   -- NB: the argument has to be eta-expanded to match
   --     the type of gzip's argument type, which is
   --     GenericQ (GenericM Maybe)
@@ -40,7 +40,7 @@ tests = gzip (\x y -> mkTT maxS x y) genCom1 genCom2 ~=? output
         (Just (x'::a),Just (y'::a)) -> cast (f x' y')
         _                           -> Nothing
 
-output = Just (C [D "Research" (E (P "Laemmel" "Amsterdam") (S 8000.0)) 
+output = Just (C [D "Research" (E (P "Laemmel" "Amsterdam") (S 8000.0))
            [PU (E (P "Joost" "Amsterdam") (S 2000.0))
            ,PU (E (P "Marlow" "Cambridge") (S 4000.0))]
            ,D "Strategy" (E (P "Blair" "London") (S 100000.0)) []])

--- a/tests/GenUpTo.hs
+++ b/tests/GenUpTo.hs
@@ -9,7 +9,7 @@ namely all terms of a given depth are generated.
 
 -}
 
-import Test.HUnit
+import Test.Tasty.HUnit
 
 import Data.Generics
 
@@ -18,17 +18,17 @@ import Data.Generics
 
 The following datatypes comprise the abstract syntax of a simple
 imperative language. Some provisions are such that the discussion
-of test-set generation is simplified. In particular, we do not 
+of test-set generation is simplified. In particular, we do not
 consider anything but monomorphic *data*types --- no primitive
 types, no tuples, ...
 
 -}
- 
-data Prog = Prog Dec Stat 
+
+data Prog = Prog Dec Stat
             deriving (Show, Eq, Typeable, Data)
 
 data Dec  = Nodec
-          | Ondec Id Type 
+          | Ondec Id Type
           | Manydecs Dec Dec
             deriving (Show, Eq, Typeable, Data)
 
@@ -43,7 +43,7 @@ data Stat = Noop
           | Seq Stat Stat
             deriving (Show, Eq, Typeable, Data)
 
-data Exp = Zero 
+data Exp = Zero
          | Succ Exp
            deriving (Show, Eq, Typeable, Data)
 
@@ -62,7 +62,7 @@ genUpTo d = result
 
      -- Find all terms headed by a specific Constr
      recurse :: Data a => Constr -> [a]
-     recurse con = gmapM (\_ -> genUpTo (d-1)) 
+     recurse con = gmapM (\_ -> genUpTo (d-1))
                          (fromConstr con)
 
      -- We could also deal with primitive types easily.
@@ -75,7 +75,7 @@ genUpTo d = result
               FloatRep    -> [mkIntegralConstr ty 0]
               CharRep     -> [mkCharConstr ty 'x']
       where
-        ty = dataTypeOf (head result)     
+        ty = dataTypeOf (head result)
 
 
 -- For silly tests
@@ -89,6 +89,6 @@ tests = (   genUpTo 0 :: [Id]
         , ( genUpTo 2 :: [Id]
         , ( genUpTo 2 :: [T0]
         , ( genUpTo 3 :: [Prog]
-        ))))) ~=? output
+        ))))) @=? output
 
 output = ([],([A,B],([A,B],([T0 T1a T2a T3a,T0 T1a T2a T3b,T0 T1a T2b T3a,T0 T1a T2b T3b,T0 T1b T2a T3a,T0 T1b T2a T3b,T0 T1b T2b T3a,T0 T1b T2b T3b],[Prog Nodec Noop,Prog Nodec (Assign A Zero),Prog Nodec (Assign B Zero),Prog Nodec (Seq Noop Noop),Prog (Ondec A Int) Noop,Prog (Ondec A Int) (Assign A Zero),Prog (Ondec A Int) (Assign B Zero),Prog (Ondec A Int) (Seq Noop Noop),Prog (Ondec A Bool) Noop,Prog (Ondec A Bool) (Assign A Zero),Prog (Ondec A Bool) (Assign B Zero),Prog (Ondec A Bool) (Seq Noop Noop),Prog (Ondec B Int) Noop,Prog (Ondec B Int) (Assign A Zero),Prog (Ondec B Int) (Assign B Zero),Prog (Ondec B Int) (Seq Noop Noop),Prog (Ondec B Bool) Noop,Prog (Ondec B Bool) (Assign A Zero),Prog (Ondec B Bool) (Assign B Zero),Prog (Ondec B Bool) (Seq Noop Noop),Prog (Manydecs Nodec Nodec) Noop,Prog (Manydecs Nodec Nodec) (Assign A Zero),Prog (Manydecs Nodec Nodec) (Assign B Zero),Prog (Manydecs Nodec Nodec) (Seq Noop Noop)]))))

--- a/tests/GetC.hs
+++ b/tests/GetC.hs
@@ -3,11 +3,11 @@
 
 module GetC (tests) where
 
-import Test.HUnit
+import Test.Tasty.HUnit
 
 {-
 
-Ralf Laemmel, 5 November 2004 
+Ralf Laemmel, 5 November 2004
 
 Joe Stoy suggested the idiom to test for the outermost constructor.
 
@@ -35,7 +35,7 @@ data T3 = T3  !Int                            deriving (Typeable, Data)
 tests = show [ isC T1a (T1a 1 "foo")   -- typechecks, returns True
              , isC T1a (T1b "foo" 1)   -- typechecks, returns False
              , isC T3  (T3 42)]        -- works for strict data too
-        ~=? output
+        @=? output
 -- err = show $ isC T2b (T1b "foo" 1)  -- must not typecheck
 
 output = show [True,False,True]
@@ -47,7 +47,7 @@ output = show [True,False,True]
 -- The class GetC computes maybe the constructor ...
 -- ... if the subterms of the datum at hand fit for f.
 -- Finally we compare the constructors.
--- 
+--
 
 isC :: (Data a, GetT f a, GetC f) => f -> a -> Bool
 isC f t = maybe False ((==) (toConstr t)) con
@@ -59,18 +59,18 @@ isC f t = maybe False ((==) (toConstr t)) con
 --
 -- We prepare for a list of kids using existential envelopes.
 -- We could also just operate on TypeReps for non-strict datatypes.
--- 
+--
 
 data ExTypeable = forall a. Typeable a => ExTypeable a
 unExTypeable (ExTypeable a) = cast a
 
 
--- 
+--
 -- Compute the result type of a function type.
 -- Beware: the TypeUnify constraint causes headache.
 -- We can't have GetT t t because the FD will be violated then.
--- We can't omit the FD because unresolvable overlapping will hold then. 
--- 
+-- We can't omit the FD because unresolvable overlapping will hold then.
+--
 
 class GetT f t | f -> t -- FD is optional
 instance GetT g t => GetT (x -> g) t
@@ -79,7 +79,7 @@ instance TypeUnify t t' => GetT t t'
 
 --
 -- Obtain the constructor if term can be completed
---  
+--
 
 class GetC f
  where
@@ -104,7 +104,7 @@ instance Data t => GetC t
 -- Type unification; we could try this:
 --  class TypeUnify a b | a -> b, b -> a
 --  instance TypeUnify a a
--- 
+--
 -- However, if the instance is placed in the present module,
 -- then type improvement would inline this instance. Sigh!!!
 --
@@ -114,8 +114,8 @@ instance Data t => GetC t
 --
 
 class    TypeUnify   a  b   |    a -> b,   b -> a
-class    TypeUnify'  x  a b |  x a -> b, x b -> a  
-class    TypeUnify'' x  a b |  x a -> b, x b -> a  
+class    TypeUnify'  x  a b |  x a -> b, x b -> a
+class    TypeUnify'' x  a b |  x a -> b, x b -> a
 instance TypeUnify'  () a b => TypeUnify    a b
 instance TypeUnify'' x  a b => TypeUnify' x a b
 instance TypeUnify'' () a a

--- a/tests/HList.hs
+++ b/tests/HList.hs
@@ -8,7 +8,7 @@ This module illustrates heterogeneously typed lists.
 
 -}
 
-import Test.HUnit
+import Test.Tasty.HUnit
 
 import Data.Typeable
 
@@ -16,7 +16,7 @@ import Data.Typeable
 -- Heterogeneously typed lists
 type HList = [DontKnow]
 
-data DontKnow = forall a. Typeable a => DontKnow a 
+data DontKnow = forall a. Typeable a => DontKnow a
 
 -- The empty list
 initHList :: HList
@@ -57,6 +57,6 @@ tests = (   show (nth1HList 1 mylist :: Maybe Int)    -- shows Just 1
         , ( show (nth1HList 1 mylist :: Maybe Bool)   -- shows Nothing
         , ( show (nth1HList 2 mylist :: Maybe Bool)   -- shows Just True
         , ( show (nth1HList 3 mylist :: Maybe String) -- shows Just "42"
-        )))) ~=? output
+        )))) @=? output
 
 output = ("Just 1",("Nothing",("Just True","Just \"42\"")))

--- a/tests/HOPat.hs
+++ b/tests/HOPat.hs
@@ -12,7 +12,7 @@ our setting.
 
 -}
 
-import Test.HUnit
+import Test.Tasty.HUnit
 
 import Data.Generics
 
@@ -31,7 +31,7 @@ elim' c y = if toConstr y == c
 
 
 -- Unwrap a term; Return its single component
-unwrap :: (Data y, Data x) => y -> Maybe x 
+unwrap :: (Data y, Data x) => y -> Maybe x
 unwrap y = case gmapQ (Nothing `mkQ` Just) y of
              [Just x] -> Just x
              _ -> Nothing
@@ -48,7 +48,7 @@ visitor :: (Data x, Data y, Data z)
 visitor c f = everywhere (mkT g)
   where
     g y = case elim c y of
-            Just x  -> c (f x) 
+            Just x  -> c (f x)
             Nothing -> y
 
 
@@ -58,7 +58,7 @@ tests = ( (  elim' (toConstr t1a) t1a) :: Maybe Int
         , ( (elim  T1a t1a)            :: Maybe Int
         , ( (elim  T1a t1b)            :: Maybe Int
         , ( (visitor T1a ((+) 46) t2)  :: T2
-        ))))) ~=? output
+        ))))) @=? output
  where
    t1a = T1a 42
    t1b = T1b 3.14

--- a/tests/Labels.hs
+++ b/tests/Labels.hs
@@ -4,7 +4,7 @@ module Labels (tests) where
 
 -- This module tests availability of field labels.
 
-import Test.HUnit
+import Test.Tasty.HUnit
 
 import Data.Generics
 
@@ -25,6 +25,6 @@ yesLabels = YesLabels 42 3.14
 -- Main function for testing
 tests = ( constrFields $ toConstr noLabels
         , constrFields $ toConstr yesLabels
-        ) ~=? output
+        ) @=? output
 
 output = ([],["myint","myfloat"])

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -1,7 +1,8 @@
 
 module Main where
 
-import Test.HUnit
+import Test.Tasty
+import Test.Tasty.HUnit
 import System.Exit
 
 import qualified Bits
@@ -41,42 +42,34 @@ import qualified LocalQuantors    -- no tests, should compile
 import qualified NestedDatatypes  -- no tests, should compile
 import qualified Polymatch        -- no tests, should compile
 
-
-tests =
-  "All" ~: [ Datatype.tests
-           , FoldTree.tests
-           , GetC.tests
-           , GMapQAssoc.tests
-           , GRead.tests
-           , GShow.tests
-           , GShow2.tests
-           , HList.tests
-           , HOPat.tests
-           , Labels.tests
-           , Newtype.tests
-           , Perm.tests
-           , Twin.tests
-           , Typecase1.tests
-           , Typecase2.tests
-           , Where.tests
-           , XML.tests
-           , Tree.tests
-           , Strings.tests
-           , Reify.tests
-           , Paradise.tests
-           , GZip.tests
-           , GEq.tests
-           , GenUpTo.tests
-           , FreeNames.tests
-           , Ext1.tests
-           , Ext2.tests
-           , Bits.tests
-           , Builders.tests
-           ]
-
-main = do
-         putStrLn "Running tests for syb..."
-         counts <- runTestTT tests
-         if (failures counts > 0)
-           then exitFailure
-             else exitSuccess
+main = defaultMain $ testGroup "All"
+  [ testCase "Datatype"   Datatype.tests
+  , testCase "FoldTree"   FoldTree.tests
+  , testCase "GetC"       GetC.tests
+  , testCase "GMapQAssoc" GMapQAssoc.tests
+  , testCase "GRead"      GRead.tests
+  , testCase "GShow"      GShow.tests
+  , testCase "GShow2"     GShow2.tests
+  , testCase "HList"      HList.tests
+  , testCase "HOPat"      HOPat.tests
+  , testCase "Labels"     Labels.tests
+  , testCase "Newtype"    Newtype.tests
+  , testCase "Perm"       Perm.tests
+  , testCase "Twin"       Twin.tests
+  , testCase "Typecase1"  Typecase1.tests
+  , testCase "Typecase2"  Typecase2.tests
+  , testCase "Where"      Where.tests
+  , testCase "XML"        XML.tests
+  , testCase "Tree"       Tree.tests
+  , testCase "Strings"    Strings.tests
+  , testCase "Reify"      Reify.tests
+  , testCase "Paradise"   Paradise.tests
+  , testCase "GZip"       GZip.tests
+  , testCase "GEq"        GEq.tests
+  , testCase "GenUpTo"    GenUpTo.tests
+  , testCase "FreeNames"  FreeNames.tests
+  , testCase "Ext1"       Ext1.tests
+  , testCase "Ext2"       Ext2.tests
+  , testCase "Bits"       Bits.tests
+  , testCase "Builders"   Builders.tests
+  ]

--- a/tests/Newtype.hs
+++ b/tests/Newtype.hs
@@ -5,13 +5,13 @@ module Newtype (tests) where
 
 -- The type of a newtype should treat the newtype as opaque
 
-import Test.HUnit
+import Test.Tasty.HUnit
 
 import Data.Generics
 
 newtype T = MkT Int deriving( Typeable )
 
-tests = show (typeOf (undefined :: T)) ~?= output
+tests = show (typeOf (undefined :: T)) @?= output
 
 #if __GLASGOW_HASKELL__ >= 701
 output = "T"

--- a/tests/Paradise.hs
+++ b/tests/Paradise.hs
@@ -11,7 +11,7 @@ a typical company just as shown in the boilerplate paper.
 
 -}
 
-import Test.HUnit
+import Test.Tasty.HUnit
 
 import Data.Generics
 import CompanyDatatypes
@@ -24,6 +24,6 @@ increase k = everywhere (mkT (incS k))
 incS :: Float -> Salary -> Salary
 incS k (S s) = S (s * (1+k))
 
-tests = increase 0.1 genCom ~=? output
+tests = increase 0.1 genCom @=? output
 
 output = C [D "Research" (E (P "Laemmel" "Amsterdam") (S 8800.0)) [PU (E (P "Joost" "Amsterdam") (S 1100.0)),PU (E (P "Marlow" "Cambridge") (S 2200.0))],D "Strategy" (E (P "Blair" "London") (S 110000.0)) []]

--- a/tests/Perm.hs
+++ b/tests/Perm.hs
@@ -9,7 +9,7 @@ Disclaimer: this is a perhaps naive, certainly undebugged example.
 
 -}
 
-import Test.HUnit
+import Test.Tasty.HUnit
 
 import Control.Applicative (Alternative(..), Applicative(..))
 import Control.Monad
@@ -134,6 +134,6 @@ tests =
    , ( runReadT buildT ["T3","T1","T2"] :: Maybe T3 -- should parse fine
    , ( runReadT buildT ["T3","T2","T1"] :: Maybe T3 -- should parse fine
    , ( runReadT buildT ["T3","T2","T2"] :: Maybe T3 -- should fail
-   ))))) ~=? output
+   ))))) @=? output
 
 output = (Just T1,(Just T2,(Just (T3 T1 T2),(Just (T3 T1 T2),Nothing))))

--- a/tests/Reify.hs
+++ b/tests/Reify.hs
@@ -10,7 +10,7 @@ types and constructors as means to steer the generation.
 
 -}
 
-import Test.HUnit
+import Test.Tasty.HUnit
 
 import Data.Maybe
 import Data.Generics
@@ -406,7 +406,7 @@ tests = (   test0
         , ( test8
         , ( test9
         , ( test10
-        ))))))))))) ~=? output
+        ))))))))))) @=? output
 
 output = (True,(True,(False,(True,(True,(1,(2,(3,(P "foo" "foo",
            (E (P "foo" "foo") (S 1.23),

--- a/tests/Strings.hs
+++ b/tests/Strings.hs
@@ -11,11 +11,11 @@ read term is equal to the original term in terms of "geq".
 
 -}
 
-import Test.HUnit
+import Test.Tasty.HUnit
 
 import Data.Generics
 import CompanyDatatypes
 
 tests = (case gread (gshow genCom) of
            [(x,_)] -> geq genCom x
-           _ -> False) ~=? True
+           _ -> False) @=? True

--- a/tests/Tree.hs
+++ b/tests/Tree.hs
@@ -9,7 +9,7 @@ but we replace *series* by *trees* so to say.
 
 -}
 
-import Test.HUnit
+import Test.Tasty.HUnit
 
 import Control.Monad.Reader
 import Data.Generics
@@ -44,7 +44,7 @@ tree2data = gdefault `extR` atString
         con  = readConstr (dataTypeOf ta) x
 
         -- recursion per kid with accumulation
-        perkid ts = const (tail ts, tree2data (head ts)) 
+        perkid ts = const (tail ts, tree2data (head ts))
 
         -- recurse into kids
         kids x =
@@ -54,9 +54,9 @@ tree2data = gdefault `extR` atString
 
 -- Main function for testing
 tests = (   genCom
-        , ( data2tree genCom 
-        , ( (tree2data (data2tree genCom)) :: Maybe Company 
+        , ( data2tree genCom
+        , ( (tree2data (data2tree genCom)) :: Maybe Company
         , ( Just genCom == tree2data (data2tree genCom)
-        )))) ~=? output
+        )))) @=? output
 
 output = (C [D "Research" (E (P "Laemmel" "Amsterdam") (S 8000.0)) [PU (E (P "Joost" "Amsterdam") (S 1000.0)),PU (E (P "Marlow" "Cambridge") (S 2000.0))],D "Strategy" (E (P "Blair" "London") (S 100000.0)) []],(Node {rootLabel = "C", subForest = [Node {rootLabel = "(:)", subForest = [Node {rootLabel = "D", subForest = [Node {rootLabel = "Research", subForest = []},Node {rootLabel = "E", subForest = [Node {rootLabel = "P", subForest = [Node {rootLabel = "Laemmel", subForest = []},Node {rootLabel = "Amsterdam", subForest = []}]},Node {rootLabel = "S", subForest = [Node {rootLabel = "8000.0", subForest = []}]}]},Node {rootLabel = "(:)", subForest = [Node {rootLabel = "PU", subForest = [Node {rootLabel = "E", subForest = [Node {rootLabel = "P", subForest = [Node {rootLabel = "Joost", subForest = []},Node {rootLabel = "Amsterdam", subForest = []}]},Node {rootLabel = "S", subForest = [Node {rootLabel = "1000.0", subForest = []}]}]}]},Node {rootLabel = "(:)", subForest = [Node {rootLabel = "PU", subForest = [Node {rootLabel = "E", subForest = [Node {rootLabel = "P", subForest = [Node {rootLabel = "Marlow", subForest = []},Node {rootLabel = "Cambridge", subForest = []}]},Node {rootLabel = "S", subForest = [Node {rootLabel = "2000.0", subForest = []}]}]}]},Node {rootLabel = "[]", subForest = []}]}]}]},Node {rootLabel = "(:)", subForest = [Node {rootLabel = "D", subForest = [Node {rootLabel = "Strategy", subForest = []},Node {rootLabel = "E", subForest = [Node {rootLabel = "P", subForest = [Node {rootLabel = "Blair", subForest = []},Node {rootLabel = "London", subForest = []}]},Node {rootLabel = "S", subForest = [Node {rootLabel = "100000.0", subForest = []}]}]},Node {rootLabel = "[]", subForest = []}]},Node {rootLabel = "[]", subForest = []}]}]}]},(Just (C [D "Research" (E (P "Laemmel" "Amsterdam") (S 8000.0)) [PU (E (P "Joost" "Amsterdam") (S 1000.0)),PU (E (P "Marlow" "Cambridge") (S 2000.0))],D "Strategy" (E (P "Blair" "London") (S 100000.0)) []]),True)))

--- a/tests/Twin.hs
+++ b/tests/Twin.hs
@@ -1,5 +1,5 @@
 {-# OPTIONS -fglasgow-exts #-}
- 
+
 module Twin (tests) where
 
 {-
@@ -8,13 +8,13 @@ For the discussion in the 2nd boilerplate paper,
 we favour some simplified development of twin traversal.
 So the full general, stepwise story is in Data.Generics.Twin,
 but the short version from the paper is turned into a test
-case below. 
+case below.
 
 See the paper for an explanation.
- 
+
 -}
 
-import Test.HUnit
+import Test.Tasty.HUnit
 
 import Data.Generics hiding (GQ,gzipWithQ,geq)
 
@@ -29,7 +29,7 @@ newtype GQ r = GQ (GenericQ r)
 
 gzipWithQ :: GenericQ (GenericQ r)
           -> GenericQ (GenericQ [r])
-gzipWithQ f t1 t2 
+gzipWithQ f t1 t2
     = gApplyQ (gmapQ (\x -> GQ (f x)) t1) t2
 
 gApplyQ :: Data a => [GQ r] -> a -> [r]
@@ -42,7 +42,7 @@ gApplyQ qs t = reverse (snd (gfoldlQ k z t))
 newtype R r x = R { unR :: r }
 
 gfoldlQ :: (r -> GenericQ r)
-        -> r 
+        -> r
         -> GenericQ r
 
 gfoldlQ k z t = unR (gfoldl k' z' t)
@@ -85,6 +85,6 @@ tests = ( geq   [True,True] [True,True]
         , geq   [True,True] [True,False]
         , geq'' [True,True] [True,True]
         , geq'' [True,True] [True,False]
-        ) ~=? output
+        ) @=? output
 
 output = (True,False,True,False)

--- a/tests/Typecase1.hs
+++ b/tests/Typecase1.hs
@@ -10,7 +10,7 @@ Note: we only need Data.Typeable. Say: Dynamics are NOT involved.
 
 -}
 
-import Test.HUnit
+import Test.Tasty.HUnit
 
 import Data.Typeable
 import Data.Maybe
@@ -51,7 +51,7 @@ f a = (maybe (maybe (maybe others
 tests = ( f (41::Int)
         , f (88::Float)
         , f (MyCons "42")
-        , f True) ~=? output
+        , f True) @=? output
 
 output = ( "got an int, incremented: 42"
          , "got a float, multiplied by .42: 36.96"

--- a/tests/Typecase2.hs
+++ b/tests/Typecase2.hs
@@ -11,7 +11,7 @@ So we only keep a single constraint: the one for class Data.
 
 -}
 
-import Test.HUnit
+import Test.Tasty.HUnit
 
 import Data.Generics
 import Data.Maybe
@@ -52,7 +52,7 @@ f a = (maybe (maybe (maybe others
 tests = ( f (41::Int)
         , f (88::Float)
         , f (MyCons "42")
-        , f True) ~=? output
+        , f True) @=? output
 
 output = ( "got an int, incremented: 42"
          , "got a float, multiplied by .42: 36.96"

--- a/tests/Where.hs
+++ b/tests/Where.hs
@@ -48,11 +48,11 @@ b) everywhereM
 
    Attempts to reach all nodes where all the sub-traversals are performed
    in monadic bind-sequence. Failure of the traversal for a given subterm
-   implies failure of the entire traversal. Hence, the argument of 
+   implies failure of the entire traversal. Hence, the argument of
    "everywhereM" should be designed in a way that it tends to succeed
    except for the purpose of propagating a proper error in the sense of
    violating a pre-/post-condition. For example, "mkM stepfail" should
-   not be passed to "everywhereM" as it will fail for all but one term 
+   not be passed to "everywhereM" as it will fail for all but one term
    pattern; see "recovered" for a way to massage "stepfail" accordingly.
 
 c) somewhere
@@ -71,7 +71,7 @@ Contributed by Ralf Laemmel, ralf@cwi.nl
 
 -}
 
-import Test.HUnit
+import Test.Tasty.HUnit
 
 import Data.Generics
 import Control.Monad
@@ -120,6 +120,6 @@ tests = gshow ( result1,
               ( result4,
               ( result5,
               ( result6,
-              ( result7 ))))))) ~=? output
+              ( result7 ))))))) @=? output
 
 output = "((,) (T1b (T2 (T1a (88)))) ((,) (T1b (T2 (T1a (37)))) ((,) (Nothing) ((,) (Nothing) ((,) (Just (T1b (T2 (T1a (37))))) ((,) (Just (T1b (T2 (T1a (88))))) (Nothing)))))))"

--- a/tests/XML.hs
+++ b/tests/XML.hs
@@ -11,7 +11,7 @@ Haskell data as homogeneous tree structures
 
 -}
 
-import Test.HUnit
+import Test.Tasty.HUnit
 
 import Control.Applicative (Alternative(..), Applicative(..))
 import Control.Monad
@@ -44,14 +44,14 @@ type Misc      = ()
 data2content :: Data a => a -> [Content]
 data2content =         element
                `ext1Q` list
-               `extQ`  string 
+               `extQ`  string
                `extQ`  float
 
  where
 
   -- Handle an element
   element x = [CElem (Elem (tyconUQname (dataTypeName (dataTypeOf x)))
-                           [] -- no attributes 
+                           [] -- no attributes
                            (concat (gmapQ data2content x)))]
 
   -- A special case for lists
@@ -72,7 +72,7 @@ content2data :: forall a. Data a => ReadX a
 content2data = result
 
  where
- 
+
   -- Case-discriminating worker
   result =         element
            `ext1R` list
@@ -111,7 +111,7 @@ content2data = result
 
   -- Retrieve all constructors of the requested type
   consOf = dataTypeConstrs
-         $ dataTypeOf 
+         $ dataTypeOf
          $ myType
 
   -- Recurse into subterms
@@ -147,13 +147,13 @@ newtype ReadX a =
                         -> Maybe ([Content], a) }
 
 -- Run a computation
-runReadX x y = case unReadX x y of 
+runReadX x y = case unReadX x y of
                  Just ([],y) -> Just y
                  _           -> Nothing
 
 -- Read one content particle
 readX :: ReadX Content
-readX =  ReadX (\x -> if null x 
+readX =  ReadX (\x -> if null x
                         then Nothing
                         else Just (tail x, head x)
                )
@@ -198,8 +198,8 @@ tests = (   genCom
         , ( zigzag person1 :: Maybe Person
         , ( zigzag genCom  :: Maybe Company
         , ( zigzag genCom == Just genCom
-        ))))) ~=? output
- where 
+        ))))) @=? output
+ where
   -- Trealise back and forth
   zigzag :: Data a => a -> Maybe a
   zigzag = runReadX content2data . data2content


### PR DESCRIPTION
This PR mechanically replaces `HUnit` with `tasty-hunit` and uses `tasty` to manage the test suite. The motivation is that current naive test suite does not catch exceptions. So the very first test, which throws an error, interrupts execution in an abnormal way. Not only its own failure is reported unproperly, but later tests are not executed at all.

For example, under this PR it appears that #20 actually fails three tests and not just one as one could expect looking at https://travis-ci.org/github/dreixel/syb/jobs/546070807#L853 