### PR TITLE
Import `guard` in `tests/Tree.hs`

### DIFF
--- a/tests/Tree.hs
+++ b/tests/Tree.hs
@@ -12,6 +12,7 @@ but we replace *series* by *trees* so to say.
 import Test.Tasty.HUnit
 
 import Control.Monad.Reader
+import Control.Monad (guard)
 import Data.Generics
 import Data.Maybe
 import Data.Tree


### PR DESCRIPTION
mtl-2.3 stops reexporting `Control.Monad` from `Control.Monad.Reader`

See: https://github.com/haskell/mtl/pull/99