### PR TITLE
Don't run GHC 7.x on CI

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -30,33 +30,21 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         ghc:
-          - "8.0.2"
-          - "8.2.2"
-          - "8.4.4"
-          - "8.6.5"
-          - "8.8.4"
-          - "8.10.7"
-          - "9.0.2"
-          - "9.2.7"
-          - "9.4.4"
-          - "9.6.1"
+          - "8.0"
+          - "8.2"
+          - "8.4"
+          - "8.6"
+          - "8.8"
+          - "8.10"
+          - "9.0"
+          - "9.2"
+          - "9.4"
+          - "9.6"
         include:
         - os: macOS-latest
-          ghc: "9.6.1"
+          ghc: "9.6"
         - os: windows-latest
-          ghc: "9.6.1"
-        - os: ubuntu-18.04
-          ghc: "7.0.4"
-        - os: ubuntu-18.04
-          ghc: "7.2.2"
-        - os: ubuntu-18.04
-          ghc: "7.4.2"
-        - os: ubuntu-18.04
-          ghc: "7.6.3"
-        - os: ubuntu-18.04
-          ghc: "7.8.4"
-        - os: ubuntu-18.04
-          ghc: "7.10.3"
+          ghc: "9.6"
     steps:
     - uses: actions/checkout@v3
     - uses: haskell/actions/setup@v2


### PR DESCRIPTION
Since it's not so easy to run older GHCs any more it seems now is a good time to stop testing them. Addresses #44 