### PR TITLE
Rename haskell-ci.yml since it’s not autogenerated any more

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: Haskell-CI
+name: CI
 on:
   - push
   - pull_request


### PR DESCRIPTION
Address renaming suggenstion in #46.