### PR TITLE
Improve documentation of Data.Generics.Aliases and add "since" annotations to all exported functions

### DIFF
--- a/src/Data/Generics/Aliases.hs
+++ b/src/Data/Generics/Aliases.hs
@@ -596,6 +596,8 @@ ext2 def ext = maybe def id (dataCast2 ext)
 
 
 -- | Type extension of transformations for unary type constructors
+--
+-- @since 0.3
 ext2T :: (Data d, Typeable2 t)
       => (forall e. Data e => e -> e)
       -> (forall d1 d2. (Data d1, Data d2) => t d1 d2 -> t d1 d2)
@@ -604,6 +606,8 @@ ext2T def ext = unT ((T def) `ext2` (T ext))
 
 
 -- | Type extension of monadic transformations for type constructors
+--
+-- @since 0.3
 ext2M :: (Monad m, Data d, Typeable2 t)
       => (forall e. Data e => e -> m e)
       -> (forall d1 d2. (Data d1, Data d2) => t d1 d2 -> m (t d1 d2))
@@ -612,6 +616,8 @@ ext2M def ext = unM ((M def) `ext2` (M ext))
 
 
 -- | Type extension of queries for type constructors
+--
+-- @since 0.3
 ext2Q :: (Data d, Typeable2 t)
       => (d -> q)
       -> (forall d1 d2. (Data d1, Data d2) => t d1 d2 -> q)
@@ -620,6 +626,8 @@ ext2Q def ext = unQ ((Q def) `ext2` (Q ext))
 
 
 -- | Type extension of readers for type constructors
+--
+-- @since 0.3
 ext2R :: (Monad m, Data d, Typeable2 t)
       => m d
       -> (forall d1 d2. (Data d1, Data d2) => m (t d1 d2))
@@ -628,6 +636,8 @@ ext2R def ext = unR ((R def) `ext2` (R ext))
 
 
 -- | Type extension of builders for type constructors
+--
+-- @since 0.3
 ext2B :: (Data a, Typeable2 t)
       => a
       -> (forall d1 d2. (Data d1, Data d2) => (t d1 d2))

--- a/src/Data/Generics/Aliases.hs
+++ b/src/Data/Generics/Aliases.hs
@@ -469,6 +469,11 @@ x `orElse` y = case x of
                  Nothing -> y
 
 
+------------------------------------------------------------------------------
+--
+-- Function combinators on generic functions
+--
+------------------------------------------------------------------------------
 {-
 
 The following variations take "orElse" to the function
@@ -482,21 +487,29 @@ queries a given constant is returned.
 -}
 
 -- | Choice for monadic transformations
+--
+-- @since 0.1.0.0
 choiceMp :: MonadPlus m => GenericM m -> GenericM m -> GenericM m
 choiceMp f g x = f x `mplus` g x
 
 
 -- | Choice for monadic queries
+--
+-- @since 0.1.0.0
 choiceQ :: MonadPlus m => GenericQ (m r) -> GenericQ (m r) -> GenericQ (m r)
 choiceQ f g x = f x `mplus` g x
 
 
 -- | Recover from the failure of monadic transformation by identity
+--
+-- @since 0.1.0.0
 recoverMp :: MonadPlus m => GenericM m -> GenericM m
 recoverMp f = f `choiceMp` return
 
 
 -- | Recover from the failure of monadic query by a constant
+--
+-- @since 0.1.0.0
 recoverQ :: MonadPlus m => r -> GenericQ (m r) -> GenericQ (m r)
 recoverQ r f = f `choiceQ` const (return r)
 

--- a/src/Data/Generics/Aliases.hs
+++ b/src/Data/Generics/Aliases.hs
@@ -91,6 +91,7 @@ import Data.Data
 -- >>> mkT not 'a'
 -- 'a'
 --
+-- @since 0.1.0.0
 mkT :: ( Typeable a
        , Typeable b
        )
@@ -112,6 +113,7 @@ mkT = extT id
 -- >>> mkQ "default" (show :: Bool -> String) ()
 -- "default"
 --
+-- @since 0.1.0.0
 mkQ :: ( Typeable a
        , Typeable b
        )
@@ -136,6 +138,7 @@ mkQ :: ( Typeable a
 -- >>> mkM (\x -> [x, not x]) (5 :: Int)
 -- [5]
 --
+-- @since 0.1.0.0
 mkM :: ( Monad m
        , Typeable a
        , Typeable b
@@ -166,6 +169,7 @@ use a point-free style whenever possible.
 -- >>> mkMp (\x -> Just (not x)) 'a'
 -- Nothing
 --
+-- @since 0.1.0.0
 mkMp :: ( MonadPlus m
         , Typeable a
         , Typeable b
@@ -188,6 +192,7 @@ mkMp = extM (const mzero)
 -- >>> mkR (Just True) :: Maybe Int
 -- Nothing
 --
+-- @since 0.1.0.0
 mkR :: ( MonadPlus m
        , Typeable a
        , Typeable b
@@ -206,6 +211,7 @@ mkR f = mzero `extR` f
 -- >>> ext0 [1 :: Int, 2, 3] [4 :: Int, 5, 6] :: [Int]
 -- [4,5,6]
 --
+-- @since 0.1.0.0
 ext0 :: (Typeable a, Typeable b) => c a -> c b -> c a
 ext0 def ext = maybe def id (gcast ext)
 
@@ -220,6 +226,7 @@ ext0 def ext = maybe def id (gcast ext)
 -- >>> extT id not 'a'
 -- 'a'
 --
+-- @since 0.1.0.0
 extT :: ( Typeable a
         , Typeable b
         )
@@ -240,6 +247,7 @@ extT def ext = unT ((T def) `ext0` (T ext))
 -- >>> extQ (const True) not 'a'
 -- True
 --
+-- @since 0.1.0.0
 extQ :: ( Typeable a
         , Typeable b
         )
@@ -260,6 +268,7 @@ extQ f g a = maybe (f a) g (cast a)
 -- >>> extM (\x -> [x,x])(\x -> [not x, x]) (5 :: Int)
 -- [5,5]
 --
+-- @since 0.1.0.0
 extM :: ( Monad m
         , Typeable a
         , Typeable b
@@ -278,6 +287,7 @@ extM def ext = unM ((M def) `ext0` (M ext))
 -- >>> extMp (\x -> [x,x])(\x -> [not x, x]) (5 :: Int)
 -- [5,5]
 --
+-- @since 0.1.0.0
 extMp :: ( MonadPlus m
          , Typeable a
          , Typeable b
@@ -296,6 +306,7 @@ extMp = extM
 -- >>> extB True False
 -- False
 --
+-- @since 0.1.0.0
 extB :: ( Typeable a
         , Typeable b
         )
@@ -313,6 +324,7 @@ extB a = maybe a id . cast
 -- >>> extR (Just True) (Just False)
 -- Just False
 --
+-- @since 0.1.0.0
 extR :: ( Monad m
         , Typeable a
         , Typeable b
@@ -332,42 +344,53 @@ extR def ext = unR ((R def) `ext0` (R ext))
 -- | Generic transformations,
 --   i.e., take an \"a\" and return an \"a\"
 --
+-- @since 0.1.0.0
 type GenericT = forall a. Data a => a -> a
 
 -- | The type synonym `GenericT` has a polymorphic type, and can therefore not
 --   appear in places where monomorphic types are expected, for example in a list.
 --   The newtype `GenericT'` wraps `GenericT` in a newtype to lift this restriction.
+--
+-- @since 0.1.0.0
 newtype GenericT' = GT { unGT :: GenericT }
 
 -- | Generic queries of type \"r\",
 --   i.e., take any \"a\" and return an \"r\"
 --
+-- @since 0.1.0.0
 type GenericQ r = forall a. Data a => a -> r
 
 -- | The type synonym `GenericQ` has a polymorphic type, and can therefore not
 --   appear in places where monomorphic types are expected, for example in a list.
 --   The newtype `GenericQ'` wraps `GenericQ` in a newtype to lift this restriction.
+--
+-- @since 0.1.0.0
 newtype GenericQ' r = GQ { unGQ :: GenericQ r }
 
 -- | Generic monadic transformations,
 --   i.e., take an \"a\" and compute an \"a\"
 --
+-- @since 0.1.0.0
 type GenericM m = forall a. Data a => a -> m a
 
 -- | The type synonym `GenericM` has a polymorphic type, and can therefore not
 --   appear in places where monomorphic types are expected, for example in a list.
 --   The newtype `GenericM'` wraps `GenericM` in a newtype to lift this restriction.
+--
+-- @since 0.1.0.0
 newtype GenericM' m = GM { unGM :: GenericM m }
 
 -- | Generic builders
 --   i.e., produce an \"a\".
 --
+-- @since 0.1.0.0
 type GenericB = forall a. Data a => a
 
 
 -- | Generic readers, say monadic builders,
 --   i.e., produce an \"a\" with the help of a monad \"m\".
 --
+-- @since 0.1.0.0
 type GenericR m = forall a. Data a => m a
 
 
@@ -375,12 +398,15 @@ type GenericR m = forall a. Data a => m a
 --   assumed by gfoldl; there are isomorphisms such as
 --   GenericT = Generic T.
 --
+-- @since 0.1.0.0
 type Generic c = forall a. Data a => a -> c a
 
 
 -- | The type synonym `Generic` has a polymorphic type, and can therefore not
 --   appear in places where monomorphic types are expected, for example in a list.
 --   The data type `Generic'` wraps `Generic` in a data type to lift this restriction.
+--
+-- @since 0.1.0.0
 data Generic' c = Generic' { unGeneric' :: Generic c }
 
 ------------------------------------------------------------------------------
@@ -405,6 +431,7 @@ data Generic' c = Generic' { unGeneric' :: Generic c }
 -- >>> orElse (Just 'a') (Just 'b')
 -- Just 'a'
 --
+-- @since 0.1.0.0
 orElse :: Maybe a -> Maybe a -> Maybe a
 x `orElse` y = case x of
                  Just _  -> x

--- a/src/Data/Generics/Aliases.hs
+++ b/src/Data/Generics/Aliases.hs
@@ -525,6 +525,8 @@ recoverQ r f = f `choiceQ` const (return r)
 #endif
 
 -- | Flexible type extension
+--
+-- @since 0.3
 ext1 :: (Data a, Typeable1 t)
      => c a
      -> (forall d. Data d => c (t d))
@@ -533,6 +535,8 @@ ext1 def ext = maybe def id (dataCast1 ext)
 
 
 -- | Type extension of transformations for unary type constructors
+--
+-- @since 0.1.0.0
 ext1T :: (Data d, Typeable1 t)
       => (forall e. Data e => e -> e)
       -> (forall f. Data f => t f -> t f)
@@ -541,6 +545,8 @@ ext1T def ext = unT ((T def) `ext1` (T ext))
 
 
 -- | Type extension of monadic transformations for type constructors
+--
+-- @since 0.1.0.0
 ext1M :: (Monad m, Data d, Typeable1 t)
       => (forall e. Data e => e -> m e)
       -> (forall f. Data f => t f -> m (t f))
@@ -549,6 +555,8 @@ ext1M def ext = unM ((M def) `ext1` (M ext))
 
 
 -- | Type extension of queries for type constructors
+--
+-- @since 0.1.0.0
 ext1Q :: (Data d, Typeable1 t)
       => (d -> q)
       -> (forall e. Data e => t e -> q)
@@ -557,6 +565,8 @@ ext1Q def ext = unQ ((Q def) `ext1` (Q ext))
 
 
 -- | Type extension of readers for type constructors
+--
+-- @since 0.1.0.0
 ext1R :: (Monad m, Data d, Typeable1 t)
       => m d
       -> (forall e. Data e => m (t e))
@@ -565,6 +575,8 @@ ext1R def ext = unR ((R def) `ext1` (R ext))
 
 
 -- | Type extension of builders for type constructors
+--
+-- @since 0.2
 ext1B :: (Data a, Typeable1 t)
       => a
       -> (forall b. Data b => (t b))

--- a/src/Data/Generics/Aliases.hs
+++ b/src/Data/Generics/Aliases.hs
@@ -9,16 +9,16 @@
 -- Stability   :  experimental
 -- Portability :  non-portable (local universal quantification)
 --
--- \"Scrap your boilerplate\" --- Generic programming in Haskell 
--- See <http://www.cs.uu.nl/wiki/GenericProgramming/SYB>.
--- The present module provides a number of declarations for typical generic
+-- This module provides a number of declarations for typical generic
 -- function types, corresponding type case, and others.
 --
 -----------------------------------------------------------------------------
 
 module Data.Generics.Aliases (
 
-        -- * Combinators to \"make\" generic functions via cast
+        -- * Combinators which create generic functions via cast
+        --
+        -- $castcombinators
         mkT, mkQ, mkM, mkMp, mkR,
         ext0, extT, extQ, extM, extMp, extB, extR,
 
@@ -78,6 +78,32 @@ import Data.Data
 --      We use type-safe cast in a number of ways to make generic functions.
 --
 ------------------------------------------------------------------------------
+
+-- $castcombinators
+--
+-- Other programming languages sometimes provide an operator @instanceof@ which
+-- can check whether an expression is an instance of a given type. This operator
+-- allows programmers to implement a function @f :: forall a. a -> a@ which exhibits
+-- a different behaviour depending on whether a `Bool` or a `Char` is passed.
+-- In Haskell this is not the case: A function with type @forall a. a -> a@
+-- can only be the identity function or a function which loops indefinitely
+-- or throws an exception. That is, it must implement exactly the same behaviour
+-- for any type at which it is used. But sometimes it is very useful to have
+-- a function which can accept (almost) any type and show a different behaviour
+-- for different types. Haskell provides this functionality with the 'Typeable'
+-- typeclass, whose instances can be automatically derived by GHC for almost all
+-- types. This typeclass allows the definition of a functon 'cast' which has type
+-- @forall a b. (Typeable a, Typeable b) => a -> Maybe b@. The 'cast' function allows
+-- to implement a polymorphic function with different behaviour at different types:
+--
+-- >>> cast True :: Maybe Bool
+-- Just True
+--
+-- >>> cast True :: Maybe Int
+-- Nothing
+--
+-- This section provides combinators which make use of 'cast' internally to
+-- provide various polymorphic functions with type-specific behaviour.
 
 -- | Make a generic transformation;
 --   start from a type-specific case;

--- a/src/Data/Generics/Aliases.hs
+++ b/src/Data/Generics/Aliases.hs
@@ -228,9 +228,10 @@ mkMp :: ( MonadPlus m
 mkMp = extM (const mzero)
 
 
--- | Make a generic builder;
---   start from a type-specific case;
---   resort to no build (i.e., mzero) otherwise
+-- | Make a generic reader from a type-specific case.
+-- The function created by @mkR f@ behaves like the reader @f@ if an expression
+-- of type @a@ can be cast to type @b@, and like the expression @mzero@ otherwise.
+-- The name 'mkR' is short for "make reader".
 --
 -- === __Examples__
 --
@@ -245,7 +246,9 @@ mkR :: ( MonadPlus m
        , Typeable a
        , Typeable b
        )
-    => m b -> m a
+    => m b
+    -- ^ The type-specific reader
+    -> m a
 mkR f = mzero `extR` f
 
 
@@ -377,7 +380,10 @@ extMp :: ( MonadPlus m
 extMp = extM
 
 
--- | Extend a generic builder
+-- | Extend a generic builder by a type-specific case.
+-- The builder created by @extB def ext@ returns @def@ if @ext@ cannot be cast
+-- to type @a@, and like @ext@ otherwise.
+-- The name 'extB' is short for "extend builder".
 --
 -- === __Examples__
 --
@@ -391,11 +397,19 @@ extMp = extM
 extB :: ( Typeable a
         , Typeable b
         )
-     => a -> b -> a
+     => a
+     -- ^ The default result
+     -> b
+     -- ^ The argument we try to cast to type @a@
+     -> a
 extB a = maybe a id . cast
 
 
--- | Extend a generic reader
+-- | Extend a generic reader by a type-specific case.
+-- The reader created by @extR def ext@ behaves like the reader @def@
+-- if expressions of type @b@ cannot be cast to type @a@, and like the
+-- reader @ext@ otherwise.
+-- The name 'extR' is short for "extend reader".
 --
 -- === __Examples__
 --
@@ -410,7 +424,11 @@ extR :: ( Monad m
         , Typeable a
         , Typeable b
         )
-     => m a -> m b -> m a
+     => m a
+     -- ^ The generic reader we want to extend
+     -> m b
+     -- ^ The type-specific reader
+     -> m a
 extR def ext = unR ((R def) `ext0` (R ext))
 
 

--- a/src/Data/Generics/Aliases.hs
+++ b/src/Data/Generics/Aliases.hs
@@ -4,7 +4,7 @@
 -- Module      :  Data.Generics.Aliases
 -- Copyright   :  (c) The University of Glasgow, CWI 2001--2004
 -- License     :  BSD-style (see the LICENSE file)
--- 
+--
 -- Maintainer  :  generics@haskell.org
 -- Stability   :  experimental
 -- Portability :  non-portable (local universal quantification)
@@ -22,17 +22,23 @@ module Data.Generics.Aliases (
         mkT, mkQ, mkM, mkMp, mkR,
         ext0, extT, extQ, extM, extMp, extB, extR,
 
-        -- * Type synonyms for generic function types
+        -- * Types for generic functions
+        -- ** Generic transformations
         GenericT,
+        GenericT'(..),
+        -- ** Generic queries
         GenericQ,
+        GenericQ'(..),
+        -- ** Generic monadic transformations
         GenericM,
+        GenericM'(..),
+        -- ** Generic builders
         GenericB,
+        -- ** Generic readers
         GenericR,
+        -- ** Generic functions
         Generic,
         Generic'(..),
-        GenericT'(..),
-        GenericQ'(..),
-        GenericM'(..),
 
         -- * Ingredients of generic functions
         orElse,
@@ -318,7 +324,7 @@ extR def ext = unR ((R def) `ext0` (R ext))
 
 ------------------------------------------------------------------------------
 --
---      Type synonyms for generic function types
+--      Types for generic functions
 --
 ------------------------------------------------------------------------------
 
@@ -328,18 +334,30 @@ extR def ext = unR ((R def) `ext0` (R ext))
 --
 type GenericT = forall a. Data a => a -> a
 
+-- | The type synonym `GenericT` has a polymorphic type, and can therefore not
+--   appear in places where monomorphic types are expected, for example in a list.
+--   The newtype `GenericT'` wraps `GenericT` in a newtype to lift this restriction.
+newtype GenericT' = GT { unGT :: GenericT }
 
 -- | Generic queries of type \"r\",
 --   i.e., take any \"a\" and return an \"r\"
 --
 type GenericQ r = forall a. Data a => a -> r
 
+-- | The type synonym `GenericQ` has a polymorphic type, and can therefore not
+--   appear in places where monomorphic types are expected, for example in a list.
+--   The newtype `GenericQ'` wraps `GenericQ` in a newtype to lift this restriction.
+newtype GenericQ' r = GQ { unGQ :: GenericQ r }
 
 -- | Generic monadic transformations,
 --   i.e., take an \"a\" and compute an \"a\"
 --
 type GenericM m = forall a. Data a => a -> m a
 
+-- | The type synonym `GenericM` has a polymorphic type, and can therefore not
+--   appear in places where monomorphic types are expected, for example in a list.
+--   The newtype `GenericM'` wraps `GenericM` in a newtype to lift this restriction.
+newtype GenericM' m = GM { unGM :: GenericM m }
 
 -- | Generic builders
 --   i.e., produce an \"a\".
@@ -360,17 +378,16 @@ type GenericR m = forall a. Data a => m a
 type Generic c = forall a. Data a => a -> c a
 
 
--- | Wrapped generic functions;
---   recall: [Generic c] would be legal but [Generic' c] not.
---
+-- | The type synonym `Generic` has a polymorphic type, and can therefore not
+--   appear in places where monomorphic types are expected, for example in a list.
+--   The data type `Generic'` wraps `Generic` in a data type to lift this restriction.
 data Generic' c = Generic' { unGeneric' :: Generic c }
 
-
--- | Other first-class polymorphic wrappers
-newtype GenericT'   = GT { unGT :: forall a. Data a => a -> a }
-newtype GenericQ' r = GQ { unGQ :: GenericQ r }
-newtype GenericM' m = GM { unGM :: forall a. Data a => a -> m a }
-
+------------------------------------------------------------------------------
+--
+-- Ingredients of generic functions
+--
+------------------------------------------------------------------------------
 
 -- | Left-biased choice on maybes
 --

--- a/src/Data/Generics/Builders.hs
+++ b/src/Data/Generics/Builders.hs
@@ -6,7 +6,7 @@
 -- Module      :  Data.Generics.Builders
 -- Copyright   :  (c) 2008 Universiteit Utrecht
 -- License     :  BSD-style
--- 
+--
 -- Maintainer  :  generics@haskell.org
 -- Stability   :  experimental
 -- Portability :  non-portable
@@ -22,6 +22,8 @@ import Data.Generics.Aliases (extB)
 
 -- | Construct the empty value for a datatype. For algebraic datatypes, the
 -- leftmost constructor is chosen.
+--
+-- @since 0.2
 empty :: forall a. Data a => a
 empty = general 
       `extB` char 
@@ -43,6 +45,8 @@ empty = general
 
 -- | Return a list of values of a datatype. Each value is one of the possible
 -- constructors of the datatype, populated with 'empty' values.
+--
+-- @since 0.2
 constrs :: forall a. Data a => [a]
 constrs = general
       `extB` char

--- a/src/Data/Generics/Schemes.hs
+++ b/src/Data/Generics/Schemes.hs
@@ -48,7 +48,8 @@ import Data.Generics.Aliases
 import Control.Monad
 
 -- | Apply a transformation everywhere in bottom-up manner
-
+--
+-- @since 0.1.0.0
 everywhere :: (forall a. Data a => a -> a)
            -> (forall a. Data a => a -> a)
 
@@ -62,6 +63,8 @@ everywhere f = go
     go = f . gmapT go
 
 -- | Apply a transformation everywhere in top-down manner
+--
+-- @since 0.1.0.0
 everywhere' :: (forall a. Data a => a -> a)
             -> (forall a. Data a => a -> a)
 
@@ -73,6 +76,8 @@ everywhere' f = go
 
 
 -- | Variation on everywhere with an extra stop condition
+--
+-- @since 0.1.0.0
 everywhereBut :: GenericQ Bool -> GenericT -> GenericT
 
 -- Guarded to let traversal cease if predicate q holds for x
@@ -85,6 +90,8 @@ everywhereBut q f = go
 
 
 -- | Monadic variation on everywhere
+--
+-- @since 0.1.0.0
 everywhereM :: forall m. Monad m => GenericM m -> GenericM m
 
 -- Bottom-up order is also reflected in order of do-actions
@@ -97,6 +104,8 @@ everywhereM f = go
 
 
 -- | Apply a monadic transformation at least somewhere
+--
+-- @since 0.1.0.0
 somewhere :: forall m. MonadPlus m => GenericM m -> GenericM m
 
 -- We try "f" in top-down manner, but descent into "x" when we fail
@@ -110,6 +119,8 @@ somewhere f = go
 
 
 -- | Summarise all nodes in top-down, left-to-right order
+--
+-- @since 0.1.0.0
 everything :: forall r. (r -> r -> r) -> GenericQ r -> GenericQ r
 
 -- Apply f to x to summarise top-level node;
@@ -122,6 +133,8 @@ everything k f = go
     go x = foldl k (f x) (gmapQ go x)
 
 -- | Variation of "everything" with an added stop condition
+--
+-- @since 0.3
 everythingBut :: forall r. (r -> r -> r) -> GenericQ (r, Bool) -> GenericQ r
 everythingBut k f = go
   where
@@ -133,6 +146,8 @@ everythingBut k f = go
 
 -- | Summarise all nodes in top-down, left-to-right order, carrying some state
 -- down the tree during the computation, but not left-to-right to siblings.
+--
+-- @since 0.3.7
 everythingWithContext :: forall s r. s -> (r -> r -> r) -> GenericQ (s -> (r, s)) -> GenericQ r
 everythingWithContext s0 f q = go s0
   where
@@ -141,11 +156,15 @@ everythingWithContext s0 f q = go s0
       where (r, s') = q x s
 
 -- | Get a list of all entities that meet a predicate
+--
+-- @since 0.1.0.0
 listify :: Typeable r => (r -> Bool) -> GenericQ [r]
 listify p = everything (++) ([] `mkQ` (\x -> if p x then [x] else []))
 
 
 -- | Look up a subterm by means of a maybe-typed filter
+--
+-- @since 0.1.0.0
 something :: GenericQ (Maybe u) -> GenericQ (Maybe u)
 
 -- "something" can be defined in terms of "everything"
@@ -159,6 +178,7 @@ something = everything orElse
 --   2nd argument o is for reduction of results from subterms;
 --   3rd argument f updates the synthesised data according to the given term
 --
+-- @since 0.1.0.0
 synthesize :: forall s t. s  -> (t -> s -> s) -> GenericQ (s -> t) -> GenericQ t
 synthesize z o f = go
   where
@@ -167,36 +187,50 @@ synthesize z o f = go
 
 
 -- | Compute size of an arbitrary data structure
+--
+-- @since 0.1.0.0
 gsize :: Data a => a -> Int
 gsize t = 1 + sum (gmapQ gsize t)
 
 
 -- | Count the number of immediate subterms of the given term
+--
+-- @since 0.1.0.0
 glength :: GenericQ Int
 glength = length . gmapQ (const ())
 
 
 -- | Determine depth of the given term
+--
+-- @since 0.1.0.0
 gdepth :: GenericQ Int
 gdepth = (+) 1 . foldr max 0 . gmapQ gdepth
 
 
 -- | Determine the number of all suitable nodes in a given term
+--
+-- @since 0.1.0.0
 gcount :: GenericQ Bool -> GenericQ Int
 gcount p =  everything (+) (\x -> if p x then 1 else 0)
 
 
 -- | Determine the number of all nodes in a given term
+--
+-- @since 0.1.0.0
 gnodecount :: GenericQ Int
 gnodecount = gcount (const True)
 
 
 -- | Determine the number of nodes of a given type in a given term
+--
+-- @since 0.1.0.0
 gtypecount :: Typeable a => a -> GenericQ Int
 gtypecount (_::a) = gcount (False `mkQ` (\(_::a) -> True))
 
 
 -- | Find (unambiguously) an immediate subterm of a given type
+--
+-- @since 0.1.0.0
 gfindtype :: (Data x, Typeable y) => x -> Maybe y
 gfindtype = singleton
           . foldl unJust []

--- a/src/Data/Generics/Text.hs
+++ b/src/Data/Generics/Text.hs
@@ -40,10 +40,14 @@ import Text.Read.Lex
 
 
 -- | Generic show: an alternative to \"deriving Show\"
+--
+-- @since 0.1.0.0
 gshow :: Data a => a -> String
 gshow x = gshows x ""
 
 -- | Generic shows
+--
+-- @since 0.2
 gshows :: Data a => a -> ShowS
 
 -- This is a prefix-show using surrounding "(" and ")",
@@ -57,6 +61,8 @@ gshows = ( \t ->
 
 
 -- | Generic read: an alternative to \"deriving Read\"
+--
+-- @since 0.1.0.0
 gread :: Data a => ReadS a
 
 {-

--- a/src/Data/Generics/Twins.hs
+++ b/src/Data/Generics/Twins.hs
@@ -82,7 +82,8 @@ Applying the same scheme we obtain an accumulating gfoldl.
 --------------------------------------------------------------}
 
 -- | gfoldl with accumulation
-
+--
+-- @since 0.1.0.0
 gfoldlAccum :: Data d
             => (forall e r. Data e => a -> c (e -> r) -> e -> (a, c r))
             -> (forall g. a -> g -> (a, c g))
@@ -99,6 +100,8 @@ newtype A a c d = A { unA :: a -> (a, c d) }
 
 
 -- | gmapT with accumulation
+--
+-- @since 0.1.0.0
 gmapAccumT :: Data d
            => (forall e. Data e => a -> e -> (a,e))
            -> a -> d -> (a, d)
@@ -111,6 +114,8 @@ gmapAccumT f a0 d0 = let (a1, d1) = gfoldlAccum k z a0 d0
 
 
 -- | Applicative version
+--
+-- @since 0.2
 gmapAccumA :: forall b d a. (Data d, Applicative a)
            => (forall e. Data e => b -> e -> (b, a e))
            -> b -> d -> (b, a d)
@@ -127,6 +132,8 @@ gmapAccumA f a0 d0 = gfoldlAccum k z a0 d0
 
 
 -- | gmapM with accumulation
+--
+-- @since 0.1.0.0
 gmapAccumM :: (Data d, Monad m)
            => (forall e. Data e => a -> e -> (a, m e))
            -> a -> d -> (a, m d)
@@ -138,6 +145,8 @@ gmapAccumM f = gfoldlAccum k z
 
 
 -- | gmapQl with accumulation
+--
+-- @since 0.1.0.0
 gmapAccumQl :: Data d
             => (r -> r' -> r)
             -> r
@@ -152,6 +161,8 @@ gmapAccumQl o r0 f a0 d0 = let (a1, r1) = gfoldlAccum k z a0 d0
 
 
 -- | gmapQr with accumulation
+--
+-- @since 0.1.0.0
 gmapAccumQr :: Data d
             => (r' -> r -> r)
             -> r
@@ -166,6 +177,8 @@ gmapAccumQr o r0 f a0 d0 = let (a1, l) = gfoldlAccum k z a0 d0
 
 
 -- | gmapQ with accumulation
+--
+-- @since 0.1.0.0
 gmapAccumQ :: Data d
            => (forall e. Data e => a -> e -> (a,q))
            -> a -> d -> (a, [q])
@@ -201,6 +214,8 @@ newtype Qr r a = Qr { unQr  :: r -> r }
 
 
 -- | Twin map for transformation
+--
+-- @since 0.1.0.0
 gzipWithT :: GenericQ (GenericT) -> GenericQ (GenericT)
 gzipWithT f x y = case gmapAccumT perkid funs y of
                     ([], c) -> c
@@ -212,6 +227,8 @@ gzipWithT f x y = case gmapAccumT perkid funs y of
 
 
 -- | Twin map for monadic transformation
+--
+-- @since 0.1.0.0
 gzipWithM :: Monad m => GenericQ (GenericM m) -> GenericQ (GenericM m)
 gzipWithM f x y = case gmapAccumM perkid funs y of
                     ([], c) -> c
@@ -222,6 +239,8 @@ gzipWithM f x y = case gmapAccumM perkid funs y of
 
 
 -- | Twin map for queries
+--
+-- @since 0.1.0.0
 gzipWithQ :: GenericQ (GenericQ r) -> GenericQ (GenericQ [r])
 gzipWithQ f x y = case gmapAccumQ perkid funs y of
                    ([], r) -> r
@@ -239,6 +258,8 @@ gzipWithQ f x y = case gmapAccumQ perkid funs y of
 ------------------------------------------------------------------------------
 
 -- | Generic equality: an alternative to \"deriving Eq\"
+--
+-- @since 0.1.0.0
 geq :: Data a => a -> a -> Bool
 
 {-
@@ -264,6 +285,8 @@ geq x0 y0 = geq' x0 y0
 
 
 -- | Generic zip controlled by a function with type-specific branches
+--
+-- @since 0.1.0.0
 gzip :: GenericQ (GenericM Maybe) -> GenericQ (GenericM Maybe)
 -- See testsuite/.../Generics/gzip.hs for an illustration
 gzip f = go
@@ -277,6 +300,8 @@ gzip f = go
         else Nothing
 
 -- | Generic comparison: an alternative to \"deriving Ord\"
+--
+-- @since 0.5
 gcompare :: Data a => a -> a -> Ordering
 gcompare = gcompare'
   where


### PR DESCRIPTION
This PR mainly improves the documentation in the module `Data.Generics.Aliases`

- Add examples to the combinators in `Data.Generics.Aliases`
- Add an explanatory text which explains how these generic combinators are implemented using the `cast` function which uses the `Typeable` class
- Improve the haddock comments for the combinators in `Data.Generics.Aliases`
- Add subsections to the module, and slightly rearrange the exported functions in a hopefully more rational order.
- Do some archeology and add `@since x.x.x.x` annotations to all currently exported functions, also those in the other modules. I didn't do this yet for the typeclass instances, since all the CPP code makes that a bit more difficult to figure out.