### PR TITLE
Factor recursion out of gshows.

### DIFF
--- a/src/Data/Generics/Text.hs
+++ b/src/Data/Generics/Text.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE RankNTypes #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Generics.Text
@@ -18,7 +19,7 @@
 module Data.Generics.Text (
 
     -- * Generic show
-    gshow, gshows,
+    gshow, gshows, gshowsF,  
 
     -- * Generic read
     gread

--- a/src/Data/Generics/Text.hs
+++ b/src/Data/Generics/Text.hs
@@ -52,13 +52,16 @@ gshows :: Data a => a -> ShowS
 
 -- This is a prefix-show using surrounding "(" and ")",
 -- where we recurse into subterms with gmapQ.
-gshows = ( \t ->
+gshows = gshowsF gshows
+
+--  This allows for users to extend gshowsF with custom implementation for certain datatypes
+gshowsF :: Data b => (forall a. Data a => a -> ShowS) -> b -> ShowS 
+gshowsF fun = ( \t ->
                 showChar '('
               . (showString . showConstr . toConstr $ t)
-              . (foldr (.) id . gmapQ ((showChar ' ' .) . gshows) $ t)
+              . (foldr (.) id . gmapQ ((showChar ' ' .) . fun) $ t)
               . showChar ')'
          ) `extQ` (shows :: String -> ShowS)
-
 
 -- | Generic 'reads' (not 'read'): an alternative to @deriving@ 'Read'.
 --

--- a/src/Data/Generics/Text.hs
+++ b/src/Data/Generics/Text.hs
@@ -54,7 +54,7 @@ gshows :: Data a => a -> ShowS
 -- where we recurse into subterms with gmapQ.
 gshows = gshowsF gshows
 
---  This allows for users to extend gshowsF with custom implementation for certain datatypes
+--  | Generic 'shows' but allowing the user to change cases.
 gshowsF :: Data b => (forall a. Data a => a -> ShowS) -> b -> ShowS 
 gshowsF fun = ( \t ->
                 showChar '('


### PR DESCRIPTION
I wanted to use `gshows`, but for my specific case, certain datatypes were highly verbose but semantically void, or had a nicer implementation. I ended up rewriting `gshows` myself, but I feel one shouldn't need to reimplement functionality. I know this is a breaking change, but I don't think it should cause any problems. (gshowsF isn't that common a name)